### PR TITLE
Fixes Var::toDouble() and start-up with named import module

### DIFF
--- a/cppy3/cppy3.cpp
+++ b/cppy3/cppy3.cpp
@@ -27,6 +27,7 @@ namespace cppy3
 
     // initialize GIL
     PyEval_InitThreads();
+    PyEval_SaveThread();
   }
   
   PythonVM::PythonVM(const std::string &name, ModuleInitializer module)
@@ -45,8 +46,13 @@ namespace cppy3
     // create CPython instance without registering signal handlers
     Py_InitializeEx(0);
 
+    PyObject* sys_path = PySys_GetObject("path");
+    PyList_Append(sys_path, PyUnicode_FromString("."));
+    PyRun_SimpleString(std::string("import " + name).c_str());
+
     // initialize GIL
     PyEval_InitThreads();
+    PyEval_SaveThread();
   }
 
   PythonVM::~PythonVM()
@@ -383,7 +389,7 @@ namespace cppy3
 
   double Var::toDouble() const
   {
-    long value = 0;
+    double value = 0;
     extract(_o, value);
     return value;
   }

--- a/cppy3/cppy3.hpp
+++ b/cppy3/cppy3.hpp
@@ -33,7 +33,7 @@ namespace cppy3
   class Var;
   class List;
   class Dict;
-  class PyExceptionData;
+  struct PyExceptionData;
   class PythonException;
   class Main;
 


### PR DESCRIPTION
Please review my proposed fixes - at least the toDouble() and the missing calls to PyEval_SaveThread()